### PR TITLE
Add s2i scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.dll
 *.so
 *.dylib
-bin
+/bin
 
 # Test binary, build with `go test -c`
 *.test

--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+echo "Assembling GOPATH..."
+PACKAGE_NAME="github.com/golang-starters/golang-rest-http"
+export GOPATH=`realpath $HOME/go`
+echo "Assembling GOPATH... DONE"
+
+
+mkdir -p $GOPATH/src/$PACKAGE_NAME
+mv /tmp/src/* $GOPATH/src/$PACKAGE_NAME
+cd $GOPATH/src/$PACKAGE_NAME
+
+echo "Resolving dependencies..."
+go get -v
+echo "Resolving dependencies... DONE"
+
+echo "Building..."
+go build -o /tmp/gobinary
+echo "Building... DONE"

--- a/.s2i/bin/run
+++ b/.s2i/bin/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+exec /tmp/gobinary

--- a/.s2i/environment
+++ b/.s2i/environment
@@ -1,1 +1,0 @@
-GOPROJECT_ROOT=github.com/golang-starters/golang-rest-http


### PR DESCRIPTION
This PR
 - Removes the s2i/environment file (`amsokol/golang-openshift:1.9.2-1` builder image needs this file. `centos/go-toolset-7-centos7:latest` doesn't)
- Add s2i scripts to build the project with `centos/go-toolset-7-centos7:latest` builder image.